### PR TITLE
Set command to "none" on error

### DIFF
--- a/src/speech.rs
+++ b/src/speech.rs
@@ -344,7 +344,7 @@ pub async fn _audio_to_text(
         // no command, we do nothing
         KakaiaCommandType::None => {
             KakaiaResponse::new(
-                &kakaia_command.string,
+                "none",
                 "no command",
                 &converted.raw,
                 0.0
@@ -363,7 +363,7 @@ pub async fn _audio_to_text(
                 )
             } else {
                 KakaiaResponse::new(
-                    &kakaia_command.string,
+                    "none",
                     "not understood",
                     &converted.raw,
                     0.0
@@ -437,7 +437,7 @@ pub async fn _audio_to_text(
                 )
             } else {
                 KakaiaResponse::new(
-                    &kakaia_command.string,
+                    "none",
                     "not understood",
                     &converted.raw,
                     0.0
@@ -485,7 +485,7 @@ pub async fn _audio_to_text(
                 )
             } else {
                 KakaiaResponse::new(
-                    &kakaia_command.string,
+                    "none",
                     "not understood",
                     &converted.raw,
                     0.0


### PR DESCRIPTION
Was playing with Kakaia today and noticed this:

```
$ curl --data @yes.base64 http://127.0.0.1:8088/convert/audio/text
{"command":"simpleCalculation","human":"not understood","raw":"audio file must have exactly 1 track, not 2","result":0.0}
```

I assume the command should be "none" as it is in other places in the source, and this was just a copy/paste typo. Now it looks like:

```
$ curl --data @yes2.base64 http://127.0.0.1:8088/convert/audio/text
{"command":"none","human":"not understood","raw":"audio file must have exactly 1 track, not 2","result":0.0}
```